### PR TITLE
Use ~ instead of ^ so that older nodes don't break

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "test262-harness": "bterlson/test262-harness"
   },
   "dependencies": {
-    "especially": "^1.6.0"
+    "especially": "~1.6.0"
   }
 }


### PR DESCRIPTION
Nodes before 0.10.something (14 i think) can't work with `^`. Using `~` is the only way to ensure that a shim (meant to work in every engine possible) works in older nodes.
