### PR TITLE
Adding trap on index -1 for the ArrayLike

### DIFF
--- a/test/Array.prototype.contains_from-index-negative-computed-index.js
+++ b/test/Array.prototype.contains_from-index-negative-computed-index.js
@@ -21,6 +21,9 @@ var arrayLike = {
     0: 'a',
     get 1() {
         return 'b';
+    },
+    get '-1'(){
+        $ERROR('Should not try to get the element at index -1');
     }
 };
 


### PR DESCRIPTION
Just adding a trap to ensure that implementation doesn't try to access negative indexes when it computes to a negative value.
