### PR TITLE
Update description to reflect latest change

### DIFF
--- a/test/Array.prototype.contains_holes.js
+++ b/test/Array.prototype.contains_holes.js
@@ -2,7 +2,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-description: Array.prototype.contains skips holes, and does not treat them as undefined
+description: Array.prototype.contains does not skips holes, and does treat them as undefined
 author: Domenic Denicola
 ---*/
 


### PR DESCRIPTION
Looking at the history of the file seems that initially it was supposed to skip holes, while in the last version it does not.
I'm updating the description in the test because is not up to date.
